### PR TITLE
Correct ID validation rules for Zimbabwe.

### DIFF
--- a/src/js/intlIdInput.js
+++ b/src/js/intlIdInput.js
@@ -1168,7 +1168,7 @@ function specialValidation(val, specialCase){
             
             return lastDigitCheck === parseInt(val[12]);
         case 'ZW_formatValidation':
-            const regex = /^\d{2}-\d{5,6}\s?[A-Z]\s?\d{2}$/;
+            const regex = /^\d{2}-\d{6,7}\s?[A-Za-z]\s?\d{2}$/;
             return regex.test(val);
         default:
             return false;


### PR DESCRIPTION
Correct validation rules for Zimbabwe.
Allow user to use uppercase and lowercase letters for ID.